### PR TITLE
typo for `FigureExtension` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ composer require jsw/commonmark-figure-extension
 ```php
 $environment = new Environment();
 $environment->addExtension(new CommonMarkCoreExtension());
-            ->addExtension(new FitureExtension());
+            ->addExtension(new FigureExtension());
 
 $converter = new MarkdownConverter($environment);
 


### PR DESCRIPTION
`FigureExtension` is misspelled as `FitureExtension` in the example code in `README.md`.