### PR TITLE
fix: correctly consume the child block, with example fenced code block

### DIFF
--- a/src/Parser/FigureParser.php
+++ b/src/Parser/FigureParser.php
@@ -63,9 +63,9 @@ final class FigureParser extends AbstractBlockContinueParser implements BlockCon
 
     public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue
     {
-        $cursor->advanceToNextNonSpaceOrTab();
+        if ('^' === $cursor->getNextNonSpaceCharacter()) {
+            $cursor->advanceToNextNonSpaceOrTab();
 
-        if ('^' === $cursor->getCurrentCharacter()) {
             if (null !== $cursor->match('/^\^{3,}/u') && !$cursor->isAtEnd()) {
                 $this->caption = $cursor->getRemainder();
             }

--- a/tests/FigureTest.php
+++ b/tests/FigureTest.php
@@ -176,7 +176,9 @@ final class FigureTest extends TestCase
         <figure><pre><code>if (condition) {
             doSomething();
         }
+            // comment behind whitespace
         //     comment with whitespace
+        // comment with trailing whitespace    
         </code></pre></figure>
 
         EOL;
@@ -187,7 +189,9 @@ final class FigureTest extends TestCase
         if (condition) {
             doSomething();
         }
+            // comment behind whitespace
         //     comment with whitespace
+        // comment with trailing whitespace    
         ```
         ^^^
         EOL;

--- a/tests/FigureTest.php
+++ b/tests/FigureTest.php
@@ -162,4 +162,34 @@ final class FigureTest extends TestCase
         $this->assertSame($expect_1, $actual_1, 'Case with more upper is failed');
         $this->assertSame($expect_2, $actual_2, 'Case with more lower is failed');
     }
+
+    public function testFigureWithCodeBlockRetainsIndent()
+    {
+        $environment = new Environment();
+
+        $environment->addExtension(new CommonMarkCoreExtension())
+            ->addExtension(new FigureExtension());
+
+        $converter = new MarkdownConverter($environment);
+
+        $expect = <<<EOL
+        <figure><pre><code>if (condition) {
+            doSomething();
+        }
+        </code></pre></figure>
+
+        EOL;
+
+        $actual_md = <<<EOL
+        ^^^
+        ```
+        if (condition) {
+            doSomething();
+        }
+        ```
+        EOL;
+        $actual = $converter->convert($actual_md)->getContent();
+
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/FigureTest.php
+++ b/tests/FigureTest.php
@@ -176,6 +176,7 @@ final class FigureTest extends TestCase
         <figure><pre><code>if (condition) {
             doSomething();
         }
+        //     comment with whitespace
         </code></pre></figure>
 
         EOL;
@@ -186,6 +187,7 @@ final class FigureTest extends TestCase
         if (condition) {
             doSomething();
         }
+        //     comment with whitespace
         ```
         ^^^
         EOL;

--- a/tests/FigureTest.php
+++ b/tests/FigureTest.php
@@ -187,6 +187,7 @@ final class FigureTest extends TestCase
             doSomething();
         }
         ```
+        ^^^
         EOL;
         $actual = $converter->convert($actual_md)->getContent();
 


### PR DESCRIPTION
This PR highlights the issue with the extensions where it will eat all the spaces from a nested code block. I'm not sure if it's due to the extension or a bug upstream.